### PR TITLE
Remove loop break and error return in CWallet::CreateTransaction.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2977,14 +2977,6 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     }
                     break; // Done, enough fee included.
                 }
-                else if (!pick_new_inputs) {
-                    // This shouldn't happen, we should have had enough excess
-                    // fee to pay for the new output and still meet nFeeNeeded
-                    // Or we should have just subtracted fee from recipients and
-                    // nFeeNeeded should not have changed
-                    strFailReason = _("Transaction fee and change calculation failed").translated;
-                    return false;
-                }
 
                 // Try to reduce change to include necessary fee
                 if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {


### PR DESCRIPTION
`CWallet::CreateTransaction` returned a false-positive error in a following scenario:
- send transaction using `sendmany` with `subtractfeefrom` set.
- bnb coin chooser is used in the first loop iteration, resulting in transaction having no change output
- fee is too small, so another loop iteration is going to be performed. Due to `subtractfeefrom` parameter being set, choosing new outputs is disabled.
- another loop iteration using knapsack is performed. This time the change output is added after initial fee calculation, so the fee is too small again. Function bumps into `else if (!pick_new_inputs)` and exits.

We allow one more loop iteration on `pick_new_inputs` disabled to let this resolve