### PR TITLE
fix: Change the way free ancestors size is calculated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev
+      - fix/*
 
 env:
   ECR_REPOSITORY: electric-cash
@@ -24,6 +25,8 @@ jobs:
         run: |
           if [[ $GITHUB_REF == 'refs/heads/dev' ]]; then
             echo "IMAGE_TAG=dev-$IMAGE_TAG" >> "$GITHUB_ENV"
+          elif [[ $GITHUB_REF == 'refs/heads/fix/'* ]]; then
+            echo "IMAGE_TAG=fix-$IMAGE_TAG" >> "$GITHUB_ENV"
           fi
 
       - name: Configure AWS credentials

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -259,8 +259,10 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
                 modEntry.nSizeWithAncestors -= it->GetTxSize();
                 modEntry.nModFeesWithAncestors -= it->GetModifiedFee();
                 modEntry.nSigOpCostWithAncestors -= it->GetSigOpCost();
-                modEntry.nFreeTxSizeWithAncestors -= it->GetFreeTxSizeWithAncestors();
-                modEntry.nFreeTxWeightWithAncestors -= it->GetFreeTxWeightWithAncestors();
+
+                modEntry.nFreeTxSizeWithAncestors -= it->GetTxFreeSize();
+                modEntry.nFreeTxWeightWithAncestors -= it->GetTxFreeWeight();
+
                 mapModifiedTx.insert(modEntry);
             } else {
                 mapModifiedTx.modify(mit, update_for_parent_inclusion(it));

--- a/src/miner.h
+++ b/src/miner.h
@@ -47,6 +47,7 @@ struct CTxMemPoolModifiedEntry {
         nTxWeight = entry->GetTxWeight();
         nFee = entry->GetFee();
         nTxFreeSize = entry->GetTxFreeSize();
+        nTxFreeWeight = entry->GetTxFreeWeight();
     }
 
     int64_t GetModifiedFee() const { return iter->GetModifiedFee(); }
@@ -67,6 +68,7 @@ struct CTxMemPoolModifiedEntry {
     int64_t nFreeTxWeightWithAncestors;
     int64_t nTxWeight;
     int64_t nTxFreeSize;
+    int64_t nTxFreeWeight;
 };
 
 /** Comparator for CTxMemPool::txiter objects.
@@ -129,6 +131,10 @@ struct update_for_parent_inclusion
     {
         e.nModFeesWithAncestors -= iter->GetFee();
         e.nSizeWithAncestors -= iter->GetTxSize();
+
+        e.nFreeTxSizeWithAncestors -= iter->GetTxFreeSize();
+        e.nFreeTxWeightWithAncestors -= iter->GetTxFreeWeight();
+
         e.nSigOpCostWithAncestors -= iter->GetSigOpCost();
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -40,13 +40,17 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
         nFreeTxSizeWithAncestors = GetTxSize();
         nFreeSizeWithDescendants = GetTxSize();
         nTxFreeSize = GetTxSize();
+
         nFreeTxWeightWithAncestors = GetTxWeight();
+        nTxFreeWeight = GetTxWeight();
     }
     else{
         nFreeTxSizeWithAncestors = 0;
         nFreeSizeWithDescendants = 0;
-        nFreeTxWeightWithAncestors = 0;
         nTxFreeSize = 0;
+
+        nFreeTxWeightWithAncestors = 0;
+        nTxFreeWeight = 0;
     }
 }
 
@@ -107,8 +111,9 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
             modifyFee += cit->GetModifiedFee();
             modifyCount++;
             cachedDescendants[updateIt].insert(cit);
-            // Update ancestor state for each descendant
-            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost(), updateIt->GetFreeTxSizeWithAncestors(), updateIt->GetFreeTxWeightWithAncestors()));
+            // Update ancestor state for each descendant-
+            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost(), updateIt->GetTxFreeSize(), updateIt->GetTxFreeWeight()));
+
         }
     }
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFreeSize, modifyFee, modifyCount));
@@ -254,8 +259,8 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncesto
         updateSize += ancestorIt->GetTxSize();
         updateFee += ancestorIt->GetModifiedFee();
         updateSigOpsCost += ancestorIt->GetSigOpCost();
-        updateFreeTxSize += ancestorIt->GetFreeTxSizeWithAncestors();
-        updateFreeTxWeight += ancestorIt->GetFreeTxWeightWithAncestors();
+        updateFreeTxSize += ancestorIt->GetTxFreeSize();
+        updateFreeTxWeight += ancestorIt->GetTxFreeWeight();
     }
     mapTx.modify(it, update_ancestor_state(updateSize, updateFee, updateCount, updateSigOpsCost, updateFreeTxSize, updateFreeTxWeight));
 }
@@ -287,8 +292,8 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
             int64_t modifySize = -((int64_t)removeIt->GetTxSize());
             CAmount modifyFee = -removeIt->GetModifiedFee();
             int modifySigOps = -removeIt->GetSigOpCost();
-            int64_t modifyFreeTxSize = -removeIt->GetFreeTxSizeWithAncestors();
-            int64_t modifyFreeTxWeight = -removeIt->GetFreeTxWeightWithAncestors();
+            int64_t modifyFreeTxSize = -removeIt->GetTxFreeSize();
+            int64_t modifyFreeTxWeight = -removeIt->GetTxFreeWeight();
             for (txiter dit : setDescendants) {
                 mapTx.modify(dit, update_ancestor_state(modifySize, modifyFee, -1, modifySigOps, modifyFreeTxSize, modifyFreeTxWeight));
             }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -76,6 +76,7 @@ private:
     int64_t feeDelta;          //!< Used for determining the priority of the transaction for mining in a block
     LockPoints lockPoints;     //!< Track the height and time at which tx was final
     int64_t nTxFreeSize;
+    int64_t nTxFreeWeight;
 
     // Information about descendants of this transaction that are in the
     // mempool; if we remove this transaction we must remove all of these
@@ -104,6 +105,7 @@ public:
     const CAmount& GetFee() const { return nFee; }
     size_t GetTxSize() const;
     size_t GetTxFreeSize() const {return nTxFreeSize; }
+    size_t GetTxFreeWeight() const {return nTxFreeWeight; }
     size_t GetTxWeight() const { return nTxWeight; }
     std::chrono::seconds GetTime() const { return std::chrono::seconds{nTime}; }
     unsigned int GetHeight() const { return entryHeight; }


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Elecric Cash Core user experience or Elecric Cash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Elecric Cash Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Elecric Cash Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
